### PR TITLE
[173] Add missing projects to the list of JVM projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,10 +12,13 @@ lazy val jsModules: Seq[ProjectReference] = Seq(
 )
 
 lazy val jvmModules: Seq[ProjectReference] = Seq(
+  benchmark,
   catsJVM,
+  commons,
   coreJVM,
   enumeratumJVM,
   genericJVM,
+  jackson,
   jodaTime,
   lawsJVM,
   libra,


### PR DESCRIPTION
Some projects, such as commons and jackson, were not added to the list of JVM projects and are not built or published from the root project.

Fixes #173 