### PR TITLE
[181] Drop Seq[String] optimisations

### DIFF
--- a/core/shared/src/main/scala/kantan/csv/RowCodec.scala
+++ b/core/shared/src/main/scala/kantan/csv/RowCodec.scala
@@ -22,6 +22,4 @@ import kantan.codecs.CodecCompanion
 object RowCodec extends GeneratedRowCodecs with CodecCompanion[Seq[String], DecodeError, codecs.type]
 
 /** All default [[RowCodec]] instances. */
-trait RowCodecInstances extends RowEncoderInstances with RowDecoderInstances {
-  implicit val stringSeqRowCodec: RowCodec[Seq[String]] = RowCodec.from(ss => DecodeResult(ss))(identity)
-}
+trait RowCodecInstances extends RowEncoderInstances with RowDecoderInstances

--- a/core/shared/src/test/scala/kantan/csv/RegressionTests.scala
+++ b/core/shared/src/test/scala/kantan/csv/RegressionTests.scala
@@ -54,4 +54,11 @@ class RegressionTests extends FunSuite with Matchers {
       List((1, "a", Some(100)), (2, "b", None))
     )
   }
+
+  test("Decoding to Seq shouldn't leak out mutability") {
+    import kantan.csv.ops._
+
+    // See #181, this used to yield Seq(Seq(3), Seq(3), Seq(3))
+    "1\n2\n3\n".unsafeReadCsv[Seq, Seq[String]](rfc) should be(Seq(Seq("1"), Seq("2"), Seq("3")))
+  }
 }


### PR DESCRIPTION
These would, in some scenarios, return broken results because mutability.

Fixes #181