### PR TITLE
Fix "Auto-application to `()` is deprecated."

### DIFF
--- a/core/shared/src/main/scala/kantan/csv/CsvReader.scala
+++ b/core/shared/src/main/scala/kantan/csv/CsvReader.scala
@@ -36,7 +36,7 @@ object CsvReader {
 
     val decoder =
       if(conf.hasHeader && data.hasNext)
-        data.next.flatMap(header => HeaderDecoder[A].fromHeader(header.map(_.trim)))
+        data.next().flatMap(header => HeaderDecoder[A].fromHeader(header.map(_.trim())))
       else Right(HeaderDecoder[A].noHeader)
 
     decoder

--- a/core/shared/src/main/scala/kantan/csv/ops/CsvRowReadingOps.scala
+++ b/core/shared/src/main/scala/kantan/csv/ops/CsvRowReadingOps.scala
@@ -35,7 +35,7 @@ final class CsvRowReadingOps[A: CsvSource](a: A) {
   def readCsvRow[B: RowDecoder](conf: CsvConfiguration)(implicit e: ReaderEngine): ReadResult[B] = {
     val reader = a.asCsvReader[B](conf)
 
-    reader.next.flatMap { res =>
+    reader.next().flatMap { res =>
       // Slight abuse of `no such element` to mean that we're not working with a single row.
       if(reader.hasNext) ParseResult.noSuchElement
       else ReadResult.success(res)


### PR DESCRIPTION
Just a fix for some warnings I stumbled upon.

The whole warning goes like this:

```
Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method XXX, 
or remove the empty argument list from its definition (Java-defined methods are exempt).
In Scala 3, an unapplied method like this will be eta-expanded into a function.
```
