### PR TITLE
Add HeaderDecoder with custom header name matching

### DIFF
--- a/core/shared/src/main/boilerplate/kantan/csv/GeneratedHeaderCodecs.scala.template
+++ b/core/shared/src/main/boilerplate/kantan/csv/GeneratedHeaderCodecs.scala.template
@@ -25,6 +25,13 @@ trait GeneratedHeaderCodecs {
   ]
 
   [#
+  def codecWith[[#A1: CellEncoder: CellDecoder#], C]([#f1: String#])(eql: (String, String) => Boolean)(f: ([#A1#]) => C)(g: C => ([#A1#])): HeaderCodec[C] =
+    HeaderCodec.from(HeaderDecoder.decoderWith([#f1#])(eql)(f))(HeaderEncoder.encoder([#f1#])(g))
+  #
+
+  ]
+
+  [#
   def caseCodec[[#A1: CellEncoder: CellDecoder#], C]([#f1: String#])(f: ([#A1#]) => C)(g: C => Option[([#A1#])]): HeaderCodec[C] =
     HeaderCodec.from(HeaderDecoder.decoder([#f1#])(f))(HeaderEncoder.caseEncoder([#f1#])(g))
   #

--- a/core/shared/src/main/boilerplate/kantan/csv/GeneratedHeaderDecoders.scala.template
+++ b/core/shared/src/main/boilerplate/kantan/csv/GeneratedHeaderDecoders.scala.template
@@ -31,11 +31,28 @@ trait GeneratedHeaderDecoders {
    * }}}
    *
    */
-  def decoder[[#A1: CellDecoder#], R]([#f1: String#])(f: ([#A1#]) => R): HeaderDecoder[R] = new HeaderDecoder[R] {
-    override def fromHeader(header: Seq[String]): DecodeResult[RowDecoder[R]] =
-      HeaderDecoder.determineRowMappings(Seq([#f1#]), header).map(mapping => RowDecoder.decoder([#mapping(0)#])(f))
-    override def noHeader = RowDecoder.ordered(f)
-  }#
+  def decoder[[#A1: CellDecoder#], R]([#f1: String#])(f: ([#A1#]) => R): HeaderDecoder[R] =
+    decoderWith([#f1#])(_ == _)(f)#
+  ]
 
+  [#/** Creates a new [[HeaderDecoder]] from the specified field list, and an equality function, and function to convert the fields into the resulting target type.
+   *
+   * @example
+   * {{{
+   * scala> import kantan.csv.ops._
+   *
+   * scala> case class Foo([#i1: Int#])
+   * scala> implicit val decoder: HeaderDecoder[Foo] = HeaderDecoder.decoderWith([#"f1"#])(_.equalsIgnoreCase(_))(Foo.apply _)
+   *
+   * scala> "[#f1#]\n[#1#]".asCsvReader[Foo](rfc.withHeader).next()
+   * res0: ReadResult[Foo] = Right(Foo([#1#,]))
+   * }}
+   *
+   */
+   def decoderWith[[#A1: CellDecoder#], R]([#f1: String#])(eql: (String, String) => Boolean)(f: ([#A1#]) => R): HeaderDecoder[R] = new HeaderDecoder[R] {
+     override def fromHeader(header: Seq[String]): DecodeResult[RowDecoder[R]] =
+       HeaderDecoder.determineRowMappings(Seq([#f1#]), header)(eql).map(mapping => RowDecoder.decoder([#mapping(0)#])(f))
+     override def noHeader = RowDecoder.ordered(f)
+   }#
   ]
 }

--- a/core/shared/src/main/scala/kantan/csv/HeaderDecoder.scala
+++ b/core/shared/src/main/scala/kantan/csv/HeaderDecoder.scala
@@ -36,10 +36,10 @@ object HeaderDecoder extends GeneratedHeaderDecoders {
   /** Summons an implicit instance of [[HeaderDecoder]] if one can be found, fails compilation otherwise. */
   def apply[A](implicit ev: HeaderDecoder[A]): HeaderDecoder[A] = macro imp.summon[HeaderDecoder[A]]
 
-  private[csv] def determineRowMappings(requiredHeader: Seq[String], csvHeader: Seq[String]): DecodeResult[Seq[Int]] =
+  private[csv] def determineRowMappings(requiredHeader: Seq[String], csvHeader: Seq[String])(eql: (String, String) => Boolean): DecodeResult[Seq[Int]] =
     requiredHeader.foldLeft((List.empty[String], List.empty[Int])) {
       case ((missing, found), header) =>
-        val index = csvHeader.indexOf(header)
+        val index = csvHeader.indexWhere(eql(header, _))
 
         if(index < 0) (header :: missing, found)
         else (missing, index :: found)


### PR DESCRIPTION
Closes #315 

Adds a new set of `decoderWith` operators to the `HeaderDecoder` and `HeaderCodec` companion objects. The old method `decoder` method now delegates to `decoderWith` but uses the default equality check for strings.

This allows users to override how the strings are compared when trying to determine the order of the headers in the mapping, e.g. when comparing the strings in a case insensitive manner.