### PR TITLE
Optional columns

### DIFF
--- a/core/shared/src/main/scala/kantan/csv/HeaderDecoder.scala
+++ b/core/shared/src/main/scala/kantan/csv/HeaderDecoder.scala
@@ -30,25 +30,26 @@ trait HeaderDecoder[A] extends Serializable { self =>
   def noHeader: RowDecoder[A]
 
   /**
-   * Combines two header decoders creating a tupled version that will decode the results from both. The combination will preserve the order
-   * of the merge in the case that no headers are detected.
-   */
-  def ~[B](that: HeaderDecoder[B])(implicit zippable: Zippable[A, B]): HeaderDecoder[zippable.Out] = new HeaderDecoder[zippable.Out] {
-    override def fromHeader(header: Seq[String]): DecodeResult[RowDecoder[zippable.Out]] =
-      for {
-        a <- self.fromHeader(header)
-        b <- that.fromHeader(header)
-      } yield (a product b).map(c => zippable.zip(c._1, c._2))
+    * Combines two header decoders creating a tupled version that will decode the results from both. The combination will preserve the order
+    * of the merge in the case that no headers are detected.
+    */
+  def ~[B](that: HeaderDecoder[B])(implicit zippable: Zippable[A, B]): HeaderDecoder[zippable.Out] =
+    new HeaderDecoder[zippable.Out] {
+      override def fromHeader(header: Seq[String]): DecodeResult[RowDecoder[zippable.Out]] =
+        for {
+          a <- self.fromHeader(header)
+          b <- that.fromHeader(header)
+        } yield (a product b).map(c => zippable.zip(c._1, c._2))
 
-    override def noHeader: RowDecoder[zippable.Out] = (self.noHeader product that.noHeader).map(c => zippable.zip(c._1, c._2))
-  }
-
-  def map[B](f: A => B): HeaderDecoder[B] = new HeaderDecoder[B] {
-    override def fromHeader(header: Seq[String]): DecodeResult[RowDecoder[B]] = {
-      self.fromHeader(header).map(_.map(f))
+      override def noHeader: RowDecoder[zippable.Out] =
+        (self.noHeader product that.noHeader).map(c => zippable.zip(c._1, c._2))
     }
 
-    override def noHeader: RowDecoder[B] = 
+  def map[B](f: A => B): HeaderDecoder[B] = new HeaderDecoder[B] {
+    override def fromHeader(header: Seq[String]): DecodeResult[RowDecoder[B]] =
+      self.fromHeader(header).map(_.map(f))
+
+    override def noHeader: RowDecoder[B] =
       self.noHeader.map(f)
   }
 }

--- a/core/shared/src/main/scala/kantan/csv/HeaderDecoder.scala
+++ b/core/shared/src/main/scala/kantan/csv/HeaderDecoder.scala
@@ -25,9 +25,32 @@ package kantan.csv
   * available), but you can create more useful [[HeaderDecoder]] instances through the
   * [[HeaderDecoder$ companion object]].
   */
-trait HeaderDecoder[A] extends Serializable {
+trait HeaderDecoder[A] extends Serializable { self =>
   def fromHeader(header: Seq[String]): DecodeResult[RowDecoder[A]]
   def noHeader: RowDecoder[A]
+
+  /**
+   * Combines two header decoders creating a tupled version that will decode the results from both. The combination will preserve the order
+   * of the merge in the case that no headers are detected.
+   */
+  def ~[B](that: HeaderDecoder[B])(implicit zippable: Zippable[A, B]): HeaderDecoder[zippable.Out] = new HeaderDecoder[zippable.Out] {
+    override def fromHeader(header: Seq[String]): DecodeResult[RowDecoder[zippable.Out]] =
+      for {
+        a <- self.fromHeader(header)
+        b <- that.fromHeader(header)
+      } yield (a product b).map(c => zippable.zip(c._1, c._2))
+
+    override def noHeader: RowDecoder[zippable.Out] = (self.noHeader product that.noHeader).map(c => zippable.zip(c._1, c._2))
+  }
+
+  def map[B](f: A => B): HeaderDecoder[B] = new HeaderDecoder[B] {
+    override def fromHeader(header: Seq[String]): DecodeResult[RowDecoder[B]] = {
+      self.fromHeader(header).map(_.map(f))
+    }
+
+    override def noHeader: RowDecoder[B] = 
+      self.noHeader.map(f)
+  }
 }
 
 /** Provides instance summoning and creation methods for [[HeaderDecoder]]. */

--- a/core/shared/src/main/scala/kantan/csv/HeaderDecoderOps1.scala
+++ b/core/shared/src/main/scala/kantan/csv/HeaderDecoderOps1.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 Nicolas Rinaudo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kantan.csv
+
+import kantan.csv.HeaderDecoderOps0.EnrichedHeaderDecoder0
+import kantan.csv.HeaderDecoderOps1.EnrichedHeaderDecoder1
+
+trait HeaderDecoderOps0 extends HeaderDecoderOps1 {
+  implicit def enrichedHeaderDecoder0[A](
+    decoder: HeaderDecoder[Option[A]]
+  ): EnrichedHeaderDecoder0[A] =
+    new EnrichedHeaderDecoder0[A](decoder)
+}
+
+object HeaderDecoderOps0 {
+  class EnrichedHeaderDecoder0[A](val decoder: HeaderDecoder[Option[A]]) extends AnyVal {
+    def optional: HeaderDecoder[Option[A]] =
+      new HeaderDecoder[Option[A]] {
+        override def fromHeader(header: Seq[String]): DecodeResult[RowDecoder[Option[A]]] =
+          decoder
+            .fromHeader(header)
+            .fold(
+              _ => DecodeResult.success(RowDecoder.from(_ => Right(None))),
+              rowDecoder => DecodeResult.success(rowDecoder)
+            )
+
+        override def noHeader: RowDecoder[Option[A]] = decoder.noHeader
+      }
+  }
+}
+
+trait HeaderDecoderOps1 {
+  implicit def enrichedHeaderDecoder1[A](
+    decoder: HeaderDecoder[A]
+  ): EnrichedHeaderDecoder1[A] =
+    new EnrichedHeaderDecoder1[A](decoder)
+
+}
+
+object HeaderDecoderOps1 {
+  class EnrichedHeaderDecoder1[A](val decoder: HeaderDecoder[A]) extends AnyVal {
+    def optional: HeaderDecoder[Option[A]] =
+      new HeaderDecoder[Option[A]] {
+        override def fromHeader(header: Seq[String]): DecodeResult[RowDecoder[Option[A]]] =
+          decoder
+            .fromHeader(header)
+            .fold(
+              _ => DecodeResult.success(RowDecoder.from(_ => Right(None))),
+              rowDecoder => DecodeResult.success(rowDecoder.map(Some(_)))
+            )
+
+        override def noHeader: RowDecoder[Option[A]] = decoder.noHeader.map(Some(_))
+      }
+  }
+}

--- a/core/shared/src/main/scala/kantan/csv/Zippable.scala
+++ b/core/shared/src/main/scala/kantan/csv/Zippable.scala
@@ -18,37 +18,37 @@ package kantan.csv
 
 // Implementation originally from https://github.com/zio/zio/blob/series/2.x/core/shared/src/main/scala/zio/Zippable.scala
 trait Zippable[-A, -B] {
-    type Out
-    def zip(left: A, right: B): Out
+  type Out
+  def zip(left: A, right: B): Out
 }
 
 object Zippable extends ZippableOps1 {
-    type Out[-A, -B, C] = Zippable[A, B] { type Out = C }
+  type Out[-A, -B, C] = Zippable[A, B] { type Out = C }
 
-    implicit def zippableLeftIdentity[A]: Zippable.Out[Unit, A, A] =
-        new Zippable[Unit, A] {
-            type Out = A
-            def zip(left: Unit, right: A) = 
-                right
-        }
+  implicit def zippableLeftIdentity[A]: Zippable.Out[Unit, A, A] =
+    new Zippable[Unit, A] {
+      type Out = A
+      def zip(left: Unit, right: A) =
+        right
+    }
 }
 
 trait ZippableOps1 extends ZippableOps2 {
-    implicit def zippableRightIdentity[A]: Zippable.Out[A, Unit, A] =
-        new Zippable[A, Unit] {
-            type Out = A
-            def zip(left: A, right: Unit) =
-                left
-        }
+  implicit def zippableRightIdentity[A]: Zippable.Out[A, Unit, A] =
+    new Zippable[A, Unit] {
+      type Out = A
+      def zip(left: A, right: Unit) =
+        left
+    }
 }
 
 trait ZippableOps2 extends ZippableOps3 {
-    implicit def zippable3[A, B, Z]: Zippable.Out[(A, B), Z, (A, B, Z)] =
-        new Zippable[(A, B), Z] {
-            type Out = (A, B, Z)
-            def zip(left: (A, B), right: Z): (A, B, Z) =
-                (left._1, left._2, right)
-        }
+  implicit def zippable3[A, B, Z]: Zippable.Out[(A, B), Z, (A, B, Z)] =
+    new Zippable[(A, B), Z] {
+      type Out = (A, B, Z)
+      def zip(left: (A, B), right: Z): (A, B, Z) =
+        (left._1, left._2, right)
+    }
 
   implicit def zippable4[A, B, C, Z]: Zippable.Out[(A, B, C), Z, (A, B, C, Z)] =
     new Zippable[(A, B, C), Z] {
@@ -427,9 +427,9 @@ trait ZippableOps2 extends ZippableOps3 {
 
 trait ZippableOps3 {
 
-    implicit def zippable2[A, B]: Zippable.Out[A, B, (A, B)] =
-        new Zippable[A, B] {
-            type Out = (A, B)
-            def zip(left: A, right: B): Out = (left, right)
-        }
+  implicit def zippable2[A, B]: Zippable.Out[A, B, (A, B)] =
+    new Zippable[A, B] {
+      type Out = (A, B)
+      def zip(left: A, right: B): Out = (left, right)
+    }
 }

--- a/core/shared/src/main/scala/kantan/csv/Zippable.scala
+++ b/core/shared/src/main/scala/kantan/csv/Zippable.scala
@@ -1,0 +1,435 @@
+/*
+ * Copyright 2015 Nicolas Rinaudo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kantan.csv
+
+// Implementation originally from https://github.com/zio/zio/blob/series/2.x/core/shared/src/main/scala/zio/Zippable.scala
+trait Zippable[-A, -B] {
+    type Out
+    def zip(left: A, right: B): Out
+}
+
+object Zippable extends ZippableOps1 {
+    type Out[-A, -B, C] = Zippable[A, B] { type Out = C }
+
+    implicit def zippableLeftIdentity[A]: Zippable.Out[Unit, A, A] =
+        new Zippable[Unit, A] {
+            type Out = A
+            def zip(left: Unit, right: A) = 
+                right
+        }
+}
+
+trait ZippableOps1 extends ZippableOps2 {
+    implicit def zippableRightIdentity[A]: Zippable.Out[A, Unit, A] =
+        new Zippable[A, Unit] {
+            type Out = A
+            def zip(left: A, right: Unit) =
+                left
+        }
+}
+
+trait ZippableOps2 extends ZippableOps3 {
+    implicit def zippable3[A, B, Z]: Zippable.Out[(A, B), Z, (A, B, Z)] =
+        new Zippable[(A, B), Z] {
+            type Out = (A, B, Z)
+            def zip(left: (A, B), right: Z): (A, B, Z) =
+                (left._1, left._2, right)
+        }
+
+  implicit def zippable4[A, B, C, Z]: Zippable.Out[(A, B, C), Z, (A, B, C, Z)] =
+    new Zippable[(A, B, C), Z] {
+      type Out = (A, B, C, Z)
+      def zip(left: (A, B, C), right: Z): (A, B, C, Z) =
+        (left._1, left._2, left._3, right)
+    }
+
+  implicit def zippable5[A, B, C, D, Z]: Zippable.Out[(A, B, C, D), Z, (A, B, C, D, Z)] =
+    new Zippable[(A, B, C, D), Z] {
+      type Out = (A, B, C, D, Z)
+      def zip(left: (A, B, C, D), right: Z): (A, B, C, D, Z) =
+        (left._1, left._2, left._3, left._4, right)
+    }
+
+  implicit def zippable6[A, B, C, D, E, Z]: Zippable.Out[(A, B, C, D, E), Z, (A, B, C, D, E, Z)] =
+    new Zippable[(A, B, C, D, E), Z] {
+      type Out = (A, B, C, D, E, Z)
+      def zip(left: (A, B, C, D, E), right: Z): (A, B, C, D, E, Z) =
+        (left._1, left._2, left._3, left._4, left._5, right)
+    }
+
+  implicit def zippable7[A, B, C, D, E, F, Z]: Zippable.Out[(A, B, C, D, E, F), Z, (A, B, C, D, E, F, Z)] =
+    new Zippable[(A, B, C, D, E, F), Z] {
+      type Out = (A, B, C, D, E, F, Z)
+      def zip(left: (A, B, C, D, E, F), right: Z): (A, B, C, D, E, F, Z) =
+        (left._1, left._2, left._3, left._4, left._5, left._6, right)
+    }
+
+  implicit def zippable8[A, B, C, D, E, F, G, Z]: Zippable.Out[(A, B, C, D, E, F, G), Z, (A, B, C, D, E, F, G, Z)] =
+    new Zippable[(A, B, C, D, E, F, G), Z] {
+      type Out = (A, B, C, D, E, F, G, Z)
+      def zip(left: (A, B, C, D, E, F, G), right: Z): (A, B, C, D, E, F, G, Z) =
+        (left._1, left._2, left._3, left._4, left._5, left._6, left._7, right)
+    }
+
+  implicit def zippable9[A, B, C, D, E, F, G, H, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H), Z, (A, B, C, D, E, F, G, H, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H), Z] {
+      type Out = (A, B, C, D, E, F, G, H, Z)
+      def zip(left: (A, B, C, D, E, F, G, H), right: Z): (A, B, C, D, E, F, G, H, Z) =
+        (left._1, left._2, left._3, left._4, left._5, left._6, left._7, left._8, right)
+    }
+
+  implicit def zippable10[A, B, C, D, E, F, G, H, I, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H, I), Z, (A, B, C, D, E, F, G, H, I, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H, I), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, Z)
+      def zip(left: (A, B, C, D, E, F, G, H, I), right: Z): (A, B, C, D, E, F, G, H, I, Z) =
+        (left._1, left._2, left._3, left._4, left._5, left._6, left._7, left._8, left._9, right)
+    }
+
+  implicit def zippable11[A, B, C, D, E, F, G, H, I, J, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H, I, J), Z, (A, B, C, D, E, F, G, H, I, J, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, Z)
+      def zip(left: (A, B, C, D, E, F, G, H, I, J), right: Z): (A, B, C, D, E, F, G, H, I, J, Z) =
+        (left._1, left._2, left._3, left._4, left._5, left._6, left._7, left._8, left._9, left._10, right)
+    }
+
+  implicit def zippable12[A, B, C, D, E, F, G, H, I, J, K, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H, I, J, K), Z, (A, B, C, D, E, F, G, H, I, J, K, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, Z)
+      def zip(left: (A, B, C, D, E, F, G, H, I, J, K), right: Z): (A, B, C, D, E, F, G, H, I, J, K, Z) =
+        (left._1, left._2, left._3, left._4, left._5, left._6, left._7, left._8, left._9, left._10, left._11, right)
+    }
+
+  implicit def zippable13[A, B, C, D, E, F, G, H, I, J, K, L, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H, I, J, K, L), Z, (A, B, C, D, E, F, G, H, I, J, K, L, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, Z)
+      def zip(left: (A, B, C, D, E, F, G, H, I, J, K, L), right: Z): (A, B, C, D, E, F, G, H, I, J, K, L, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          right
+        )
+    }
+
+  implicit def zippable14[A, B, C, D, E, F, G, H, I, J, K, L, M, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H, I, J, K, L, M), Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, Z)
+      def zip(left: (A, B, C, D, E, F, G, H, I, J, K, L, M), right: Z): (A, B, C, D, E, F, G, H, I, J, K, L, M, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          right
+        )
+    }
+
+  implicit def zippable15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H, I, J, K, L, M, N), Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          right
+        )
+    }
+
+  implicit def zippable16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z]
+    : Zippable.Out[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O), Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z)] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          left._15,
+          right
+        )
+    }
+
+  implicit def zippable17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z]: Zippable.Out[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z)
+  ] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          left._15,
+          left._16,
+          right
+        )
+    }
+
+  implicit def zippable18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z]: Zippable.Out[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z)
+  ] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          left._15,
+          left._16,
+          left._17,
+          right
+        )
+    }
+
+  implicit def zippable19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z]: Zippable.Out[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z)
+  ] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          left._15,
+          left._16,
+          left._17,
+          left._18,
+          right
+        )
+    }
+
+  implicit def zippable20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z]: Zippable.Out[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z)
+  ] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          left._15,
+          left._16,
+          left._17,
+          left._18,
+          left._19,
+          right
+        )
+    }
+
+  implicit def zippable21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z]: Zippable.Out[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z)
+  ] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          left._15,
+          left._16,
+          left._17,
+          left._18,
+          left._19,
+          left._20,
+          right
+        )
+    }
+
+  implicit def zippable22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z]: Zippable.Out[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U),
+    Z,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z)
+  ] =
+    new Zippable[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U), Z] {
+      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z)
+      def zip(
+        left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U),
+        right: Z
+      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z) =
+        (
+          left._1,
+          left._2,
+          left._3,
+          left._4,
+          left._5,
+          left._6,
+          left._7,
+          left._8,
+          left._9,
+          left._10,
+          left._11,
+          left._12,
+          left._13,
+          left._14,
+          left._15,
+          left._16,
+          left._17,
+          left._18,
+          left._19,
+          left._20,
+          left._21,
+          right
+        )
+    }
+}
+
+trait ZippableOps3 {
+
+    implicit def zippable2[A, B]: Zippable.Out[A, B, (A, B)] =
+        new Zippable[A, B] {
+            type Out = (A, B)
+            def zip(left: A, right: B): Out = (left, right)
+        }
+}

--- a/core/shared/src/main/scala/kantan/csv/package.scala
+++ b/core/shared/src/main/scala/kantan/csv/package.scala
@@ -19,7 +19,7 @@ package kantan
 import kantan.codecs.{Codec, Decoder, Encoder}
 import kantan.codecs.resource.ResourceIterator
 
-package object csv {
+package object csv extends HeaderDecoderOps0 {
 
   /** Iterator on CSV data.
     *

--- a/core/shared/src/test/scala/kantan/csv/HeaderDecoderZipTests.scala
+++ b/core/shared/src/test/scala/kantan/csv/HeaderDecoderZipTests.scala
@@ -36,7 +36,6 @@ class HeaderDecoderZipTests extends AnyFunSuite with Matchers {
 
     val lines = new ByteArrayInputStream(csv.getBytes)
       .asCsvReader[(String, String)](rfc.withHeader)
-      .iterator
       .toList
 
     lines should be(List(Right("foo" -> "bar"), Right("far" -> "baz")))
@@ -52,7 +51,6 @@ class HeaderDecoderZipTests extends AnyFunSuite with Matchers {
 
     val lines = new ByteArrayInputStream(csv.getBytes)
       .asCsvReader[(String, String, String)](rfc.withHeader)
-      .iterator
       .toList
 
     lines should be(List(Right(("bar", "foo", "baz")), Right(("baz", "far", "bau"))))
@@ -68,7 +66,6 @@ class HeaderDecoderZipTests extends AnyFunSuite with Matchers {
 
     val lines = new ByteArrayInputStream(csv.getBytes)
       .asCsvReader[(String, Option[String], String)](rfc.withHeader)
-      .iterator
       .toList
 
     lines should be(List(Right(("foo", None, "bar")), Right(("far", None, "baz"))))

--- a/core/shared/src/test/scala/kantan/csv/HeaderDecoderZipTests.scala
+++ b/core/shared/src/test/scala/kantan/csv/HeaderDecoderZipTests.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015 Nicolas Rinaudo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kantan.csv
+
+import java.io.ByteArrayInputStream
+import kantan.csv.ops._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class HeaderDecoderZipTests extends AnyFunSuite with Matchers {
+  val x = HeaderDecoder.decoder[String, String]("A")(identity)
+  val y = HeaderDecoder.decoder[String, String]("B")(identity)
+  val z = HeaderDecoder.decoder[String, String]("C")(identity)
+
+  test("Zipping two header decoders should result in a union of the two") {
+    implicit val decoder: HeaderDecoder[(String, String)] = x ~ y
+
+    val csv =
+      """A,B
+        |foo,bar
+        |far,baz""".stripMargin
+
+    val lines = new ByteArrayInputStream(csv.getBytes)
+      .asCsvReader[(String, String)](rfc.withHeader)
+      .iterator
+      .toList
+
+    lines should be(List(Right("foo" -> "bar"), Right("far" -> "baz")))
+  }
+
+  test("Zipping produces a flattened tuple") {
+    implicit val decoder: HeaderDecoder[(String, String, String)] = x ~ y ~ z
+
+    val csv =
+      """B,A,C
+        |foo,bar,baz
+        |far,baz,bau""".stripMargin
+
+    val lines = new ByteArrayInputStream(csv.getBytes)
+      .asCsvReader[(String, String, String)](rfc.withHeader)
+      .iterator
+      .toList
+
+    lines should be(List(Right(("bar", "foo", "baz")), Right(("baz", "far", "bau"))))
+  }
+
+  test("Can ignore missing columns") {
+    implicit val decoder: HeaderDecoder[(String, Option[String], String)] = x ~ y.optional ~ z
+
+    val csv =
+      """A,C
+        |foo,bar
+        |far,baz""".stripMargin
+
+    val lines = new ByteArrayInputStream(csv.getBytes)
+      .asCsvReader[(String, Option[String], String)](rfc.withHeader)
+      .iterator
+      .toList
+
+    lines should be(List(Right(("foo", None, "bar")), Right(("far", None, "baz"))))
+  }
+
+  test("optional operator is idempotent") {
+    implicit val decoder: HeaderDecoder[(String, Option[String], String)] = x ~ y.optional.optional ~ z
+
+    val csv =
+      """A,C
+        |foo,bar
+        |far,baz""".stripMargin
+
+    val lines = new ByteArrayInputStream(csv.getBytes)
+      .asCsvReader[(String, Option[String], String)](rfc.withHeader)
+      .iterator
+      .toList
+
+    lines should be(List(Right(("foo", None, "bar")), Right(("far", None, "baz"))))
+  }
+}


### PR DESCRIPTION
This PR adds the ability to specify "optional" columns (at a slight performance cost due to additional allocations). The approach here was to basically build in an `Apply`, by describing both an `product` method and `map` method for the `HeaderDecoder` type. This allows `HeaderDecoder`s to be composed together to form larger decoders (I think I could potentially also define a `pure` method for the `HeaderDecoder` which would describe a column that just has a default value, in order to get a full `Applicative` but I'm not sure if there is any utility to that).

The tests include some examples of what can be done with this approach.

Closes #215 