### PR TITLE
Preserve variance of type aliases

### DIFF
--- a/core/shared/src/main/scala/kantan/csv/package.scala
+++ b/core/shared/src/main/scala/kantan/csv/package.scala
@@ -25,7 +25,7 @@ package object csv {
     *
     * @documentable
     */
-  type CsvReader[A] = ResourceIterator[A]
+  type CsvReader[+A] = ResourceIterator[A]
 
   val rfc: CsvConfiguration = CsvConfiguration.rfc
 
@@ -38,7 +38,7 @@ package object csv {
     *
     * @documentable
     */
-  type ReadResult[A] = Either[ReadError, A]
+  type ReadResult[+A] = Either[ReadError, A]
 
   /** Result of a parsing operation.
     *
@@ -50,7 +50,7 @@ package object csv {
     *
     * @documentable
     */
-  type ParseResult[A] = Either[ParseError, A]
+  type ParseResult[+A] = Either[ParseError, A]
 
   /** Result of a decode operation.
     *
@@ -62,7 +62,7 @@ package object csv {
     *
     * @documentable
     */
-  type DecodeResult[A] = Either[DecodeError, A]
+  type DecodeResult[+A] = Either[DecodeError, A]
 
   // - Cell codecs -----------------------------------------------------------------------------------------------------
   // -------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds the covariant annotation `+` on the type parameter of the alias used in e.g. `ParseResult`, as the aliased type is using this parameter in the covariant position.

This should not cause any changes in the library, however, fixes an issue with using typeclasses from zio-prelude, which use variance annotations.